### PR TITLE
remove authentication to allow API req to /movies

### DIFF
--- a/index.js
+++ b/index.js
@@ -160,7 +160,6 @@ app.get(
 //READ- return a list of all movies to user as JSON object
 app.get(
   "/movies",
-  passport.authenticate("jwt", { session: false }),
   async (req, res) => {
     await Movies.find()
       .then((movies) => {


### PR DESCRIPTION
Since API has authentication on it, in order to render data in my React app(FlixHive-client) will need to address this by temporarily adjusting /movies endpoint.